### PR TITLE
Only remove atRule if isAllowed check passes

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ module.exports = postcss.plugin('postcss-unwrap-at-media"', function (opts) {
 					}
 					atRule.parent.insertAfter(atRule, node);
 				}
+				atRule.remove();
 			}
-			atRule.remove();
 		});
 	};
 });


### PR DESCRIPTION
atRule.remove() was executing regardless of what was passed in for `opts.disallow`